### PR TITLE
fpr

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     },
     "engines": {
         "node": ">=14"
+    },
+    "dependencies": {
+        "vite-plugin-full-reload": "^1.0.0"
     }
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -20,7 +20,7 @@ describe('laravel-vite-plugin', () => {
     })
 
     it('accepts a single input', () => {
-        const plugin = laravel('resources/js/app.ts')
+        const plugin = laravel('resources/js/app.ts')[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'production' })
         expect(config.build.rollupOptions.input).toBe('resources/js/app.ts')
@@ -33,7 +33,7 @@ describe('laravel-vite-plugin', () => {
         const plugin = laravel([
             'resources/js/app.ts',
             'resources/js/other.js',
-        ])
+        ])[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'production' })
         expect(config.build.rollupOptions.input).toEqual(['resources/js/app.ts', 'resources/js/other.js'])
@@ -49,7 +49,7 @@ describe('laravel-vite-plugin', () => {
             buildDirectory: 'other-build',
             ssr: 'resources/js/ssr.ts',
             ssrOutputDirectory: 'other-ssr-output',
-        })
+        })[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'production' })
         expect(config.base).toBe('/other-build/')
@@ -68,7 +68,7 @@ describe('laravel-vite-plugin', () => {
         const plugin = laravel({
             input: 'resources/js/app.js',
             ssr: 'resources/js/ssr.js',
-        })
+        })[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'production' })
         expect(config.base).toBe('/build/')
@@ -85,7 +85,7 @@ describe('laravel-vite-plugin', () => {
 
     it('uses the default entry point when ssr entry point is not provided', () => {
         // This is support users who may want a dedicated Vite config for SSR.
-        const plugin = laravel('resources/js/ssr.js')
+        const plugin = laravel('resources/js/ssr.js')[0]
 
         const ssrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
         expect(ssrConfig.build.rollupOptions.input).toBe('resources/js/ssr.js')
@@ -93,7 +93,7 @@ describe('laravel-vite-plugin', () => {
 
     it('prefixes the base with ASSET_URL in production mode', () => {
         process.env.ASSET_URL = 'http://example.com'
-        const plugin = laravel('resources/js/app.js')
+        const plugin = laravel('resources/js/app.js')[0]
 
         const devConfig = plugin.config({}, { command: 'serve', mode: 'development' })
         expect(devConfig.base).toBe('')
@@ -105,12 +105,12 @@ describe('laravel-vite-plugin', () => {
     })
 
     it('prevents setting an empty publicDirectory', () => {
-        expect(() => laravel({ input: 'resources/js/app.js', publicDirectory: '' }))
+        expect(() => laravel({ input: 'resources/js/app.js', publicDirectory: '' })[0])
             .toThrowError('publicDirectory must be a subdirectory');
     })
 
     it('prevents setting an empty buildDirectory', () => {
-        expect(() => laravel({ input: 'resources/js/app.js', buildDirectory: '' }))
+        expect(() => laravel({ input: 'resources/js/app.js', buildDirectory: '' })[0])
             .toThrowError('buildDirectory must be a subdirectory');
     })
 
@@ -120,7 +120,7 @@ describe('laravel-vite-plugin', () => {
             publicDirectory: '/public/test/',
             buildDirectory: '/build/test/',
             ssrOutputDirectory: '/ssr-output/test/',
-        })
+        })[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'production' })
         expect(config.base).toBe('/build/test/')
@@ -131,7 +131,7 @@ describe('laravel-vite-plugin', () => {
     })
 
     it('provides an @ alias by default', () => {
-        const plugin = laravel('resources/js/app.js')
+        const plugin = laravel('resources/js/app.js')[0]
 
         const config = plugin.config({}, { command: 'build', mode: 'development' })
 
@@ -139,7 +139,7 @@ describe('laravel-vite-plugin', () => {
     })
 
     it('respects a users existing @ alias', () => {
-        const plugin = laravel('resources/js/app.js')
+        const plugin = laravel('resources/js/app.js')[0]
 
         const config = plugin.config({
             resolve: {
@@ -153,7 +153,7 @@ describe('laravel-vite-plugin', () => {
     })
 
     it('appends an Alias object when using an alias array', () => {
-        const plugin = laravel('resources/js/app.js')
+        const plugin = laravel('resources/js/app.js')[0]
 
         const config = plugin.config({
             resolve: {
@@ -171,7 +171,7 @@ describe('laravel-vite-plugin', () => {
 
     it('configures the Vite server when inside a Sail container', () => {
         process.env.LARAVEL_SAIL = '1'
-        const plugin = laravel('resources/js/app.js')
+        const plugin = laravel('resources/js/app.js')[0]
 
         const config = plugin.config({}, { command: 'serve', mode: 'development' })
         expect(config.server.host).toBe('0.0.0.0')
@@ -184,7 +184,7 @@ describe('laravel-vite-plugin', () => {
     it('allows the Vite port to be configured when inside a Sail container', () => {
         process.env.LARAVEL_SAIL = '1'
         process.env.VITE_PORT = '1234'
-        const plugin = laravel('resources/js/app.js')
+        const plugin = laravel('resources/js/app.js')[0]
 
         const config = plugin.config({}, { command: 'serve', mode: 'development' })
         expect(config.server.host).toBe('0.0.0.0')
@@ -197,7 +197,7 @@ describe('laravel-vite-plugin', () => {
 
     it('allows the server configuration to be overridden inside a Sail container', () => {
         process.env.LARAVEL_SAIL = '1'
-        const plugin = laravel('resources/js/app.js')
+        const plugin = laravel('resources/js/app.js')[0]
 
         const config = plugin.config({
             server: {
@@ -215,7 +215,7 @@ describe('laravel-vite-plugin', () => {
 
     it('prevents the Inertia helpers from being externalized', () => {
         /* eslint-disable @typescript-eslint/ban-ts-comment */
-        const plugin = laravel('resources/js/app.js')
+        const plugin = laravel('resources/js/app.js')[0]
 
         const noSsrConfig = plugin.config({ build: { ssr: true } }, { command: 'build', mode: 'production' })
         /* @ts-ignore */
@@ -235,6 +235,121 @@ describe('laravel-vite-plugin', () => {
         const stringNoExternalConfig = plugin.config({ ssr: { noExternal: 'foo' }, build: { ssr: true } }, { command: 'build', mode: 'production' })
         /* @ts-ignore */
         expect(stringNoExternalConfig.ssr.noExternal).toEqual(['foo', 'laravel-vite-plugin'])
+    })
+
+    it('does not configure full reload when configuration it not an object', () => {
+        const plugins = laravel('resources/js/app.js')
+
+        expect(plugins.length).toBe(1)
+    })
+
+    it('does not configure full reload when fullReload is not present', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+        })
+
+        expect(plugins.length).toBe(1)
+    })
+
+    it('does not configure full reload when fullReload is set to undefined', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+            fullReload: undefined,
+        })
+        expect(plugins.length).toBe(1)
+    })
+
+    it('does not configure full reload when fullReload is false', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+            fullReload: false,
+        })
+
+        expect(plugins.length).toBe(1)
+    })
+
+    it('configures full reload with routes and views when fullReload is true', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+            fullReload: true,
+        })
+
+        expect(plugins.length).toBe(2)
+        /** @ts-ignore */
+        expect(plugins[1].__laravel_plugin_config).toEqual({
+            paths: ['resources/views/**', 'routes/**'],
+        })
+    })
+
+    it('configures full reload whenFullReload is a single path', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+            fullReload: 'path/to/watch/**',
+        })
+
+        expect(plugins.length).toBe(2)
+        /** @ts-ignore */
+        expect(plugins[1].__laravel_plugin_config).toEqual({
+            paths: ['path/to/watch/**'],
+        })
+    })
+
+    it('configures full reload when fullReload is an array of paths', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+            fullReload: ['path/to/watch/**', 'another/to/watch/**'],
+        })
+
+        expect(plugins.length).toBe(2)
+        /** @ts-ignore */
+        expect(plugins[1].__laravel_plugin_config).toEqual({
+            paths: ['path/to/watch/**', 'another/to/watch/**'],
+        })
+    })
+
+    it('configures full reload when fullReload is a complete configuration to proxy', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+            fullReload: {
+                paths: ['path/to/watch/**', 'another/to/watch/**'],
+                config: { delay: 987 }
+            },
+        })
+
+        expect(plugins.length).toBe(2)
+        /** @ts-ignore */
+        expect(plugins[1].__laravel_plugin_config).toEqual({
+            paths: ['path/to/watch/**', 'another/to/watch/**'],
+            config: { delay: 987 }
+        })
+    })
+
+    it('configures full reload when fullReload is an array of complete configurations to proxy', () => {
+        const plugins = laravel({
+            input: 'resources/js/app.js',
+            fullReload: [
+                {
+                    paths: ['path/to/watch/**'],
+                    config: { delay: 987 }
+                },
+                {
+                    paths: ['another/to/watch/**'],
+                    config: { delay: 123 }
+                },
+            ],
+        })
+
+        expect(plugins.length).toBe(3)
+        /** @ts-ignore */
+        expect(plugins[1].__laravel_plugin_config).toEqual({
+            paths: ['path/to/watch/**'],
+            config: { delay: 987 }
+        })
+        /** @ts-ignore */
+        expect(plugins[2].__laravel_plugin_config).toEqual({
+            paths: ['another/to/watch/**'],
+            config: { delay: 123 }
+        })
     })
 })
 


### PR DESCRIPTION
## How to configure

```js
import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';

export default defineConfig({
    plugins: [
        laravel({
            input: [
                'resources/css/app.css',
                'resources/js/app.js',
            ],

            // watches resources/views/** && routes/**
            fullReload: true,

            // watches provided path...
            fullReload: 'path/to/watch/**',

            // watches provided paths...
            fullReload: ['path/to/watch/**', 'another/one/**'],

            // escape hatch to fully configure the underlying plugin (as an object)
            fullReload: { paths: [/* .. */ ], config: { /* ... */ }},

            // escape hatch to fully configure the underlying plugin (as an array)
            fullReload: [{ paths: [/* .. */ ], config: { /* ... */ }}]
        }),
    ],
});


```

## Notes

- I'd ask the original plugin to export their interface so we don't need to recreate it, if we want to go ahead with this.
- This is technically a breaking change, as the plugin now returns an array, however i feel this might be okay IRL.